### PR TITLE
Added support for querying daily and monthly consumption statistics

### DIFF
--- a/lib/plug.js
+++ b/lib/plug.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const net = require('net');
+const util = require('util');
 
 const encryptWithHeader = require('./utils').encryptWithHeader;
 const decrypt = require('./utils').decrypt;
@@ -18,6 +19,8 @@ var commands = {
   getAwayRules: '{"anti_theft":{"get_rules":{}}}',
   getTimerRules: '{"count_down":{"get_rules":{}}}',
   getConsumption: '{"emeter":{"get_realtime":{}}}',
+  getDailyStatisticsForMonth: '{"emeter":{"get_daystat":{"month":%d,"year":%d}}}',
+  getMonthlyStatisticsForYear: '{"emeter":{"get_monthstat":{"year": %d}}}',
   getTime: '{"time":{"get_time":{}}}',
   getTimeZone: '{"time":{"get_timezone":{}}}',
   getScanInfo: (refresh, timeout) => `{"netif":{"get_scaninfo":{"refresh":${(refresh ? 1 : 0)},"timeout":${timeout}}}}`,
@@ -163,6 +166,25 @@ class Plug {
 
   getConsumption () {
     return this.get(commands.getConsumption).then((data) => {
+      return data.emeter;
+    });
+  }
+
+  getDailyStatisticsForMonth (month, year) {
+    var d = new Date();
+    if (typeof month === 'undefined') month = d.getMonth() + 1;
+    if (typeof year === 'undefined') year = d.getFullYear();
+    return this.get(util.format(commands.getDailyStatisticsForMonth, month, year)).then((data) => {
+      return data.emeter;
+    });
+  }
+
+  getMonthlyStatisticsForYear (year) {
+    if (typeof year === 'undefined') {
+      var d = new Date();
+      year = d.getFullYear();
+    }
+    return this.get(util.format(commands.getMonthlyStatisticsForYear, year)).then((data) => {
       return data.emeter;
     });
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hs100-api",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "TPLink HS100/HS110 WiFi Smart Plug API",
   "author": "Patrick Seal",
   "license": "MIT",


### PR DESCRIPTION
Added support for querying daily and monthly consumption statistics for TP-Link HS110, i.e. emeter.get_daystat and emeter.get_monthstat
