### PR TITLE
Add option to filter devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ options: {
   [, broadcast = '255.255.255.255']
   [, discoveryInterval = 30000]
   [, offlineTolerance = 3]
+  [, filter = false]
   [, debug = false]
 }
 ```

--- a/lib/client.js
+++ b/lib/client.js
@@ -21,6 +21,7 @@ class Client extends EventEmitter {
     this.broadcast = options.broadcast || '255.255.255.255';
     this.discoveryInterval = options.discoveryInterval || 30000;
     this.offlineTolerance = options.offlineTolerance || 3;
+    this.filter = options.filter || false;
     this.debug = options.debug || false;
 
     this.devices = new Map();
@@ -52,6 +53,15 @@ class Client extends EventEmitter {
       const sysinfo = jsonMsg.system.get_sysinfo;
       sysinfo.host = rinfo.address;
       sysinfo.port = rinfo.port;
+
+      const deviceType = sysinfo.type || sysinfo.mic_type;
+
+      if (this.filter && deviceType !== this.filter) {
+        if (this.debug) {
+          console.log('Filtered out: %s (%s)', sysinfo.alias, deviceType);
+        }
+        return;
+      }
 
       if (this.devices.has(sysinfo.deviceId)) {
         const plug = this.devices.get(sysinfo.deviceId);


### PR DESCRIPTION
Adds an option to filter discovered devices and only emit devices matching the `filter` type provided. Currently, other TP-Link devices (e.g. smart bulbs) are returned, causing issues with packages that only work with smart plugs.

The option defaults to false for backward compatibility, but I could make it default to filtering for the `IOT.SMARTPLUGSWITCH` type of the HS1xx devices if you’d rather only target smart plugs and release a new version.

I’ve verified that HS105 and HS100 identify as `IOT.SMARTPLUGSWITCH`.