### PR TITLE
More events, send state in events

### DIFF
--- a/example/events.js
+++ b/example/events.js
@@ -8,12 +8,17 @@ var logEvent = function (eventName, device) {
 
 client.on('device-new', (device) => {
   logEvent('device-new', device);
+  device.startPolling(5000);
+
   device.on('power-on', (device) => { logEvent('power-on', device); });
   device.on('power-off', (device) => { logEvent('power-off', device); });
   device.on('power-update', (device, powerOn) => { logEvent('power-update', device); });
+
   device.on('in-use', (device) => { logEvent('in-use', device); });
   device.on('not-in-use', (device) => { logEvent('not-in-use', device); });
   device.on('in-use-update', (device, inUse) => { logEvent('in-use-update', device); });
+
+  device.on('consumption-update', (device, consumption) => { logEvent('consumption-update', device); });
 });
 client.on('device-online', (device) => { logEvent('device-online', device); });
 client.on('device-offline', (device) => { logEvent('device-offline', device); });

--- a/example/events.js
+++ b/example/events.js
@@ -10,8 +10,10 @@ client.on('device-new', (device) => {
   logEvent('device-new', device);
   device.on('power-on', (device) => { logEvent('power-on', device); });
   device.on('power-off', (device) => { logEvent('power-off', device); });
+  device.on('power-update', (device, powerOn) => { logEvent('power-update', device); });
   device.on('in-use', (device) => { logEvent('in-use', device); });
   device.on('not-in-use', (device) => { logEvent('not-in-use', device); });
+  device.on('in-use-update', (device, inUse) => { logEvent('in-use-update', device); });
 });
 client.on('device-online', (device) => { logEvent('device-online', device); });
 client.on('device-offline', (device) => { logEvent('device-offline', device); });

--- a/example/events.js
+++ b/example/events.js
@@ -2,8 +2,8 @@ const Hs100Api = require('../../hs100-api');
 
 const client = new Hs100Api.Client();
 
-var logEvent = function (eventName, device) {
-  console.log(`${(new Date()).toISOString()} ${eventName} ${device.model} ${device.host} ${device.deviceId}`);
+var logEvent = function (eventName, device, state = '') {
+  console.log(`${(new Date()).toISOString()} ${eventName} ${device.model} ${device.host} ${device.deviceId} ${state}`);
 };
 
 client.on('device-new', (device) => {
@@ -12,13 +12,13 @@ client.on('device-new', (device) => {
 
   device.on('power-on', (device) => { logEvent('power-on', device); });
   device.on('power-off', (device) => { logEvent('power-off', device); });
-  device.on('power-update', (device, powerOn) => { logEvent('power-update', device); });
+  device.on('power-update', (device, powerOn) => { logEvent('power-update', device, powerOn); });
 
   device.on('in-use', (device) => { logEvent('in-use', device); });
   device.on('not-in-use', (device) => { logEvent('not-in-use', device); });
-  device.on('in-use-update', (device, inUse) => { logEvent('in-use-update', device); });
+  device.on('in-use-update', (device, inUse) => { logEvent('in-use-update', device, inUse); });
 
-  device.on('consumption-update', (device, consumption) => { logEvent('consumption-update', device); });
+  device.on('consumption-update', (device, consumption) => { logEvent('consumption-update', device, String(consumption.power) ); });
 });
 client.on('device-online', (device) => { logEvent('device-online', device); });
 client.on('device-offline', (device) => { logEvent('device-offline', device); });

--- a/src/plug.js
+++ b/src/plug.js
@@ -94,19 +94,23 @@ class Plug extends Device {
     if (this.lastState.inUse !== inUse) {
       this.lastState.inUse = inUse;
       if (inUse) {
-        this.emit('in-use', this);
+        this.emit('in-use', this, inUse);
       } else {
-        this.emit('not-in-use', this);
+        this.emit('not-in-use', this, inUse);
       }
+    } else {
+      this.emit('in-use-update', this, inUse);
     }
 
     if (this.lastState.powerOn !== powerOn) {
       this.lastState.powerOn = powerOn;
       if (powerOn) {
-        this.emit('power-on', this);
+        this.emit('power-on', this, powerOn);
       } else {
-        this.emit('power-off', this);
+        this.emit('power-off', this, powerOn);
       }
+    } else {
+      this.emit('power-update', this, powerOn);
     }
   }
 

--- a/src/plug.js
+++ b/src/plug.js
@@ -112,6 +112,10 @@ class Plug extends Device {
     } else {
       this.emit('power-update', this, powerOn);
     }
+
+    if (this.supportsConsumption) {
+      this.emit('consumption-update', this, this.consumption);
+    }
   }
 
   async getInfo () {

--- a/src/plug.js
+++ b/src/plug.js
@@ -122,7 +122,7 @@ class Plug extends Device {
     let data = await this.send('{"emeter":{"get_realtime":{}},"schedule":{"get_next_action":{}},"system":{"get_sysinfo":{}},"cnCloud":{"get_info":{}}}');
     this.sysInfo = data.system.get_sysinfo;
     this.cloudInfo = data.cnCloud.get_info;
-    this.consumption = data.emeter;
+    this.consumption = data.emeter.get_realtime;
     this.scheduleNextAction = data.schedule.get_next_action;
     return {sysInfo: this.sysInfo, cloudInfo: this.cloudInfo, consumption: this.consumption, scheduleNextAction: this.scheduleNextAction};
   }
@@ -130,7 +130,7 @@ class Plug extends Device {
   async getSysInfoAndConsumption () {
     let data = await this.send('{"emeter":{"get_realtime":{}},"system":{"get_sysinfo":{}}}');
     this.sysInfo = data.system.get_sysinfo;
-    this.consumption = data.emeter;
+    this.consumption = data.emeter.get_realtime;
     return {sysInfo: this.sysInfo, consumption: this.consumption};
   }
 


### PR DESCRIPTION
I need these features (or similar) for https://github.com/dersimn/HS100toMQTT

Currently the `*-update` events fire twice per poll for some reason.

```
Seim:hs100-api simon$ node example/events
Starting Device Discovery
2017-09-15T14:00:22.371Z device-new HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 
2017-09-15T14:00:27.410Z in-use-update HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 false
2017-09-15T14:00:27.410Z power-update HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 false
2017-09-15T14:00:27.410Z consumption-update HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 undefined
2017-09-15T14:00:27.410Z in-use-update HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 false
2017-09-15T14:00:27.410Z power-update HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 false
2017-09-15T14:00:27.410Z consumption-update HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 0
2017-09-15T14:00:32.303Z in-use-update HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 false
2017-09-15T14:00:32.303Z power-update HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 false
2017-09-15T14:00:32.303Z consumption-update HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 0
2017-09-15T14:00:32.303Z device-online HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 
2017-09-15T14:00:32.407Z in-use-update HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 false
2017-09-15T14:00:32.407Z power-update HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 false
2017-09-15T14:00:32.407Z consumption-update HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 0
2017-09-15T14:00:32.407Z in-use-update HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 false
2017-09-15T14:00:32.407Z power-update HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 false
2017-09-15T14:00:32.407Z consumption-update HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 0
2017-09-15T14:00:37.405Z in-use-update HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 false
2017-09-15T14:00:37.405Z power-update HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 false
2017-09-15T14:00:37.405Z consumption-update HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 0
2017-09-15T14:00:37.405Z in-use-update HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 false
2017-09-15T14:00:37.405Z power-update HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 false
2017-09-15T14:00:37.405Z consumption-update HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 0
2017-09-15T14:00:42.338Z in-use-update HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 false
2017-09-15T14:00:42.338Z power-update HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 false
2017-09-15T14:00:42.338Z consumption-update HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 0
2017-09-15T14:00:42.338Z device-online HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 
2017-09-15T14:00:42.408Z in-use-update HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 false
2017-09-15T14:00:42.408Z power-update HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 false
2017-09-15T14:00:42.408Z consumption-update HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 0
2017-09-15T14:00:42.408Z in-use-update HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 false
2017-09-15T14:00:42.408Z power-update HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 false
2017-09-15T14:00:42.408Z consumption-update HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 0
2017-09-15T14:00:47.413Z in-use-update HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 false
2017-09-15T14:00:47.413Z power-update HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 false
2017-09-15T14:00:47.413Z consumption-update HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 0
2017-09-15T14:00:47.413Z in-use-update HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 false
2017-09-15T14:00:47.413Z power-update HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 false
2017-09-15T14:00:47.413Z consumption-update HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 0
2017-09-15T14:00:52.373Z in-use-update HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 false
2017-09-15T14:00:52.373Z power-update HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 false
2017-09-15T14:00:52.373Z consumption-update HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 0
2017-09-15T14:00:52.373Z device-online HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 
2017-09-15T14:00:52.414Z in-use-update HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 false
2017-09-15T14:00:52.415Z power-update HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 false
2017-09-15T14:00:52.415Z consumption-update HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 0
2017-09-15T14:00:52.415Z in-use-update HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 false
2017-09-15T14:00:52.415Z power-update HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 false
2017-09-15T14:00:52.415Z consumption-update HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 0
2017-09-15T14:00:57.412Z in-use-update HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 false
2017-09-15T14:00:57.413Z power-on HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 
2017-09-15T14:00:57.413Z consumption-update HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 0
2017-09-15T14:00:57.413Z in-use HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 
2017-09-15T14:00:57.413Z power-update HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 true
2017-09-15T14:00:57.413Z consumption-update HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 3.175664
2017-09-15T14:01:02.525Z in-use-update HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 true
2017-09-15T14:01:02.525Z power-update HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 true
2017-09-15T14:01:02.525Z consumption-update HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 3.175664
2017-09-15T14:01:02.525Z in-use-update HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 true
2017-09-15T14:01:02.525Z power-update HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 true
2017-09-15T14:01:02.525Z consumption-update HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 3.484421
2017-09-15T14:01:07.422Z in-use-update HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 true
2017-09-15T14:01:07.422Z power-update HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 true
2017-09-15T14:01:07.422Z consumption-update HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 3.484421
2017-09-15T14:01:07.422Z in-use-update HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 true
2017-09-15T14:01:07.422Z power-update HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 true
2017-09-15T14:01:07.422Z consumption-update HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 2.100294
2017-09-15T14:01:12.341Z in-use-update HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 true
2017-09-15T14:01:12.341Z power-off HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 
2017-09-15T14:01:12.342Z consumption-update HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 2.100294
2017-09-15T14:01:12.342Z device-online HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 
2017-09-15T14:01:12.425Z in-use-update HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 true
2017-09-15T14:01:12.426Z power-update HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 false
2017-09-15T14:01:12.426Z consumption-update HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 2.100294
2017-09-15T14:01:12.426Z not-in-use HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 
2017-09-15T14:01:12.426Z power-update HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 false
2017-09-15T14:01:12.426Z consumption-update HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 0
2017-09-15T14:01:17.427Z in-use-update HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 false
2017-09-15T14:01:17.427Z power-update HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 false
2017-09-15T14:01:17.427Z consumption-update HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 0
2017-09-15T14:01:17.427Z in-use-update HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 false
2017-09-15T14:01:17.427Z power-update HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 false
2017-09-15T14:01:17.427Z consumption-update HS110(EU) 10.1.1.209 800630F5F2DF76599D6487862FB8BF6718FEFFE0 0
```